### PR TITLE
Update acct_mg.gemspec

### DIFF
--- a/acct_mg.gemspec
+++ b/acct_mg.gemspec
@@ -7,5 +7,5 @@ Gem::Specification.new do |s|
   s.authors     = ['Wenyu Duan']
   s.email       = 'duanwenyu1988@gmail.com'
   s.files       = ['app/']
-  s.homepage    = 'No Home Page'
+  s.homepage    = 'https://github.com/duandf35/AcctManagerCLI'
 end


### PR DESCRIPTION
It may seem minor but you the current value errors out when building the gem

```
gem build acct_mg.gemspec
ERROR:  While executing gem ... (Gem::InvalidSpecificationException)
    "No Home Page" is not a URI
```
